### PR TITLE
Add multi-platform Dockerfiles for core services

### DIFF
--- a/image/apm/8.17.0/multi-platform-alma-linux-9.dockerfile
+++ b/image/apm/8.17.0/multi-platform-alma-linux-9.dockerfile
@@ -1,0 +1,52 @@
+# Docker image to use.
+FROM --platform=linux/amd64 sloopstash/base:v1.1.1 AS install_apm_amd64
+
+# Install system packages.
+RUN yum install -y perl-Digest-SHA
+
+# Install APM.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/apm-server/apm-server-8.17.0-linux-x86_64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/apm-server/apm-server-8.17.0-linux-x86_64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c apm-server-8.17.0-linux-x86_64.tar.gz.sha512 \
+  && tar xvzf apm-server-8.17.0-linux-x86_64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/apm \
+  && cp -r apm-server-8.17.0/* /usr/local/lib/apm/ \
+  && rm -rf apm-server-8.17.0*
+
+# Docker image to use.
+FROM --platform=linux/arm64 sloopstash/base:v1.1.1 AS install_apm_arm64
+
+# Install system packages.
+RUN yum install -y perl-Digest-SHA
+
+# Install APM.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/apm-server/apm-server-8.17.0-linux-arm64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/apm-server/apm-server-8.17.0-linux-arm64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c apm-server-8.17.0-linux-arm64.tar.gz.sha512 \
+  && tar xvzf apm-server-8.17.0-linux-arm64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/apm \
+  && cp -r apm-server-8.17.0/* /usr/local/lib/apm/ \
+  && rm -rf apm-server-8.17.0*
+
+# Final Docker image setup.
+FROM install_apm_${TARGETARCH}
+
+# Create APM directories.
+RUN set -x \
+  && mkdir /opt/apm \
+  && mkdir /opt/apm/data \
+  && mkdir /opt/apm/log \
+  && mkdir /opt/apm/conf \
+  && mkdir /opt/apm/script \
+  && mkdir /opt/apm/system \
+  && touch /opt/apm/system/server.pid \
+  && touch /opt/apm/system/supervisor.ini \
+  && ln -s /opt/apm/system/supervisor.ini /etc/supervisord.d/apm.ini \
+  && history -c
+
+# Set default work directory.
+WORKDIR /opt/apm

--- a/image/elasticsearch/8.17.0/multi-platform-alma-linux-9.dockerfile
+++ b/image/elasticsearch/8.17.0/multi-platform-alma-linux-9.dockerfile
@@ -1,0 +1,66 @@
+# Docker image to use.
+FROM --platform=linux/amd64 sloopstash/alma-linux-9:v1.1.1 AS install_elasticsearch_amd64
+
+# Install system packages.
+RUN set -x \
+  && dnf install -y perl-Digest-SHA \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# Install Elasticsearch.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.17.0-linux-x86_64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.17.0-linux-x86_64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c elasticsearch-8.17.0-linux-x86_64.tar.gz.sha512 \
+  && tar xvzf elasticsearch-8.17.0-linux-x86_64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/elasticsearch \
+  && cp -r elasticsearch-8.17.0/* /usr/local/lib/elasticsearch/ \
+  && rm -rf elasticsearch-8.17.0*
+
+# Docker image to use.
+FROM --platform=linux/arm64 sloopstash/alma-linux-9:v1.1.1 AS install_elasticsearch_arm64
+
+# Install system packages.
+RUN set -x \
+  && dnf install -y perl-Digest-SHA \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# Install Elasticsearch.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.17.0-linux-aarch64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.17.0-linux-aarch64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c elasticsearch-8.17.0-linux-aarch64.tar.gz.sha512 \
+  && tar xvzf elasticsearch-8.17.0-linux-aarch64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/elasticsearch \
+  && cp -r elasticsearch-8.17.0/* /usr/local/lib/elasticsearch/ \
+  && rm -rf elasticsearch-8.17.0*
+
+# Final Docker image setup.
+FROM install_elasticsearch_${TARGETARCH}
+
+# Create system user for Elasticsearch.
+RUN useradd -m elasticsearch
+
+# Create Elasticsearch directories.
+RUN set -x \
+  && mkdir /opt/elasticsearch \
+  && mkdir /opt/elasticsearch/data \
+  && mkdir /opt/elasticsearch/log \
+  && mkdir /opt/elasticsearch/conf \
+  && mkdir /opt/elasticsearch/script \
+  && mkdir /opt/elasticsearch/system \
+  && touch /opt/elasticsearch/system/server.pid \
+  && touch /opt/elasticsearch/system/supervisor.ini \
+  && ln -sf /opt/elasticsearch/conf/server.yml /usr/local/lib/elasticsearch/config/elasticsearch.yml \
+  && ln -sf /opt/elasticsearch/conf/jvm.options /usr/local/lib/elasticsearch/config/jvm.options \
+  && ln -s /opt/elasticsearch/system/security-limit.conf /etc/security/limits.d/elasticsearch.conf \
+  && ln -s /opt/elasticsearch/system/supervisor.ini /etc/supervisord.d/elasticsearch.ini \
+  && chown -R elasticsearch:elasticsearch /usr/local/lib/elasticsearch \
+  && chown -R elasticsearch:elasticsearch /opt/elasticsearch \
+  && history -c
+
+# Set default work directory.
+WORKDIR /opt/elasticsearch

--- a/image/kibana/8.17.0/multi-platform-alma-linux-9.dockerfile
+++ b/image/kibana/8.17.0/multi-platform-alma-linux-9.dockerfile
@@ -1,0 +1,58 @@
+# Docker image to use.
+FROM --platform=linux/amd64 sloopstash/alma-linux-9:v1.1.1 AS install_kibana_amd64
+
+# Install system packages.
+RUN set -x \
+  && dnf install -y perl-Digest-SHA \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# Install Kibana.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/kibana/kibana-8.17.0-linux-x86_64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/kibana/kibana-8.17.0-linux-x86_64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c kibana-8.17.0-linux-x86_64.tar.gz.sha512 \
+  && tar xvzf kibana-8.17.0-linux-x86_64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/kibana \
+  && cp -r kibana-8.17.0/* /usr/local/lib/kibana/ \
+  && rm -rf kibana-8.17.0*
+
+# Docker image to use.
+FROM --platform=linux/arm64 sloopstash/alma-linux-9:v1.1.1 AS install_kibana_arm64
+
+# Install system packages.
+RUN set -x \
+  && dnf install -y perl-Digest-SHA \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# Install Kibana.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/kibana/kibana-8.17.0-linux-aarch64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/kibana/kibana-8.17.0-linux-aarch64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c kibana-8.17.0-linux-aarch64.tar.gz.sha512 \
+  && tar xvzf kibana-8.17.0-linux-aarch64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/kibana \
+  && cp -r kibana-8.17.0/* /usr/local/lib/kibana/ \
+  && rm -rf kibana-8.17.0*
+
+# Final Docker image setup.
+FROM install_kibana_${TARGETARCH}
+
+# Create Kibana directories.
+RUN set -x \
+  && mkdir /opt/kibana \
+  && mkdir /opt/kibana/data \
+  && mkdir /opt/kibana/log \
+  && mkdir /opt/kibana/conf \
+  && mkdir /opt/kibana/script \
+  && mkdir /opt/kibana/system \
+  && touch /opt/kibana/system/server.pid \
+  && touch /opt/kibana/system/supervisor.ini \
+  && ln -s /opt/kibana/system/supervisor.ini /etc/supervisord.d/kibana.ini \
+  && history -c
+
+# Set default work directory.
+WORKDIR /opt/kibana

--- a/image/logstash/8.17.0/multi-platform-alma-linux-9.dockerfile
+++ b/image/logstash/8.17.0/multi-platform-alma-linux-9.dockerfile
@@ -1,0 +1,61 @@
+# Docker image to use.
+FROM --platform=linux/amd64 sloopstash/alma-linux-9:v1.1.1 AS install_logstash_amd64
+
+# Install system packages.
+RUN set -x \
+  && dnf install -y perl-Digest-SHA \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# Install Logstash.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/logstash/logstash-8.17.0-linux-x86_64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/logstash/logstash-8.17.0-linux-x86_64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c logstash-8.17.0-linux-x86_64.tar.gz.sha512 \
+  && tar xvzf logstash-8.17.0-linux-x86_64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/logstash \
+  && cp -r logstash-8.17.0/* /usr/local/lib/logstash/ \
+  && rm -rf logstash-8.17.0*
+
+# Docker image to use.
+FROM --platform=linux/arm64 sloopstash/alma-linux-9:v1.1.1 AS install_logstash_arm64
+
+# Install system packages.
+RUN set -x \
+  && dnf install -y perl-Digest-SHA \
+  && dnf clean all \
+  && rm -rf /var/cache/dnf
+
+# Install Logstash.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://artifacts.elastic.co/downloads/logstash/logstash-8.17.0-linux-aarch64.tar.gz --quiet \
+  && wget https://artifacts.elastic.co/downloads/logstash/logstash-8.17.0-linux-aarch64.tar.gz.sha512 --quiet \
+  && shasum -a 512 -c logstash-8.17.0-linux-aarch64.tar.gz.sha512 \
+  && tar xvzf logstash-8.17.0-linux-aarch64.tar.gz > /dev/null \
+  && mkdir /usr/local/lib/logstash \
+  && cp -r logstash-8.17.0/* /usr/local/lib/logstash/ \
+  && rm -rf logstash-8.17.0*
+
+# Final Docker image setup.
+FROM install_logstash_${TARGETARCH}
+
+# Create Logstash directories.
+RUN set -x \
+  && mkdir /opt/logstash \
+  && mkdir /opt/logstash/data \
+  && mkdir /opt/logstash/log \
+  && mkdir /opt/logstash/conf \
+  && mkdir /opt/logstash/script \
+  && mkdir /opt/logstash/system \
+  && touch /opt/logstash/system/server.pid \
+  && touch /opt/logstash/system/supervisor.ini \
+  && ln -sf /opt/logstash/conf/server.yml /usr/local/lib/logstash/config/logstash.yml \
+  && ln -sf /opt/logstash/conf/jvm.options /usr/local/lib/logstash/config/jvm.options \
+  && ln -sf /opt/logstash/conf/pipelines.yml /usr/local/lib/logstash/config/pipelines.yml \
+  && ln -s /opt/logstash/system/supervisor.ini /etc/supervisord.d/logstash.ini \
+  && history -c
+
+# Set default work directory.
+WORKDIR /opt/logstash

--- a/image/mongo-db/7.0.2/multi-platform-alma-linux-9.dockerfile
+++ b/image/mongo-db/7.0.2/multi-platform-alma-linux-9.dockerfile
@@ -1,0 +1,60 @@
+# Docker image to use.
+FROM --platform=linux/amd64 sloopstash/alma-linux-9:v1.1.1 AS install_mongo_db_amd64
+
+# Install system packages.
+RUN yum install -y libcurl openssl xz-libs
+
+# Install MongoDB.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-amazon2-7.0.2.tgz --quiet \
+  && tar xvzf mongodb-linux-x86_64-amazon2-7.0.2.tgz > /dev/null \
+  && mv mongodb-linux-x86_64-amazon2-7.0.2/bin/* /usr/local/bin/ \
+  && rm -rf mongodb-linux-x86_64-amazon2-7.0.2*
+
+# Install MongoDB shell.
+RUN set -x \
+  && wget https://downloads.mongodb.com/compass/mongosh-2.1.5-linux-x64.tgz --quiet \
+  && tar xvzf mongosh-2.1.5-linux-x64.tgz > /dev/null \
+  && mv mongosh-2.1.5-linux-x64/bin/* /usr/local/bin/ \
+  && rm -rf mongosh-2.1.5-linux-x64*
+
+# Docker image to use.
+FROM --platform=linux/arm64 sloopstash/alma-linux-9:v1.1.1 AS install_mongo_db_arm64
+
+# Install system packages.
+RUN yum install -y libcurl openssl xz-libs
+
+# Install MongoDB.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-amazon2-7.0.24.tgz --quiet \
+  && tar xvzf mongodb-linux-aarch64-amazon2-7.0.24.tgz > /dev/null \
+  && mv mongodb-linux-aarch64-amazon2-7.0.24/bin/* /usr/local/bin/ \
+  && rm -rf mongodb-linux-aarch64-amazon2-7.0.24*
+
+# Install MongoDB shell.
+RUN set -x \
+  && wget https://downloads.mongodb.com/compass/mongosh-2.5.8-linux-arm64.tgz --quiet \
+  && tar xvzf mongosh-2.5.8-linux-arm64.tgz > /dev/null \
+  && mv mongosh-2.5.8-linux-arm64/bin/* /usr/local/bin/ \
+  && rm -rf mongosh-2.5.8-linux-arm64*
+
+# Final Docker image setup.
+FROM install_mongo_db_${TARGETARCH}
+
+# Create MongoDB directories.
+RUN set -x \
+  && mkdir /opt/mongo-db \
+  && mkdir /opt/mongo-db/data \
+  && mkdir /opt/mongo-db/log \
+  && mkdir /opt/mongo-db/conf \
+  && mkdir /opt/mongo-db/script \
+  && mkdir /opt/mongo-db/system \
+  && touch /opt/mongo-db/system/server.pid \
+  && touch /opt/mongo-db/system/supervisor.ini \
+  && ln -s /opt/mongo-db/system/supervisor.ini /etc/supervisord.d/mongo-db.ini \
+  && history -c
+
+# Set default work directory.
+WORKDIR /opt/mongo-db

--- a/image/nginx/1.24.0/multi-platform-amazon-linux-2.dockerfile
+++ b/image/nginx/1.24.0/multi-platform-amazon-linux-2.dockerfile
@@ -1,0 +1,44 @@
+# Docker image to use.
+FROM --platform=linux/amd64 sloopstash/base:v1.1.1 AS install_nginx_amd64
+
+# Install Nginx on amd64 platform.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://nginx.org/packages/rhel/7/x86_64/RPMS/nginx-1.24.0-1.el7.ngx.x86_64.rpm --quiet \
+  && yum install -y nginx-1.24.0-1.el7.ngx.x86_64.rpm \
+  && rm -f nginx-1.24.0-1.el7.ngx.x86_64.rpm
+
+# Docker image to use.
+FROM --platform=linux/arm64 sloopstash/base:v1.1.1 AS install_nginx_arm64
+
+# Install Nginx on arm64 platform.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://nginx.org/packages/rhel/7/aarch64/RPMS/nginx-1.24.0-1.el7.ngx.aarch64.rpm --quiet \
+  && yum install -y nginx-1.24.0-1.el7.ngx.aarch64.rpm \
+  && rm -f nginx-1.24.0-1.el7.ngx.aarch64.rpm
+
+# Final Docker image setup.
+FROM install_nginx_${TARGETARCH}
+
+# Create App and Nginx directories.
+RUN set -x \
+  && mkdir /opt/app \
+  && mkdir /opt/app/source \
+  && mkdir /opt/nginx \
+  && mkdir /opt/nginx/log \
+  && mkdir /opt/nginx/conf \
+  && mkdir /opt/nginx/script \
+  && mkdir /opt/nginx/system \
+  && touch /opt/nginx/log/access.log \
+  && touch /opt/nginx/log/error.log \
+  && touch /opt/nginx/conf/server.conf \
+  && touch /opt/nginx/conf/app.conf \
+  && touch /opt/nginx/system/server.pid \
+  && touch /opt/nginx/system/supervisor.ini \
+  && ln -s /opt/nginx/conf/app.conf /etc/nginx/conf.d/app.conf \
+  && ln -s /opt/nginx/system/supervisor.ini /etc/supervisord.d/nginx.ini \
+  && history -c
+
+# Set default work directory.
+WORKDIR /opt/nginx

--- a/image/ollama/0.9.6/multi-platform-alma-linux-9.dockerfile
+++ b/image/ollama/0.9.6/multi-platform-alma-linux-9.dockerfile
@@ -1,0 +1,49 @@
+# Docker image to use.
+FROM --platform=linux/amd64 sloopstash/alma-linux-9:v1.1.1 AS install_ollama_amd64
+
+# Install Ollama.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://github.com/ollama/ollama/releases/download/v0.9.6/ollama-linux-amd64.tgz --quiet \
+  && tar xvzf ollama-linux-amd64.tgz > /dev/null \
+  && mkdir /usr/local/lib/ollama \
+  && cp -r lib/ollama/* /usr/local/lib/ollama/ \
+  && mv bin/ollama /usr/local/bin/ \
+  && rm -rf ollama* lib bin
+ENV OLLAMA_HOST=0.0.0.0
+ENV OLLAMA_MODELS=/opt/ollama/model
+
+# Docker image to use.
+FROM --platform=linux/arm64 sloopstash/alma-linux-9:v1.1.1 AS install_ollama_arm64
+
+# Install Ollama.
+WORKDIR /tmp
+RUN set -x \
+  && wget https://github.com/ollama/ollama/releases/download/v0.9.6/ollama-linux-arm64.tgz  --quiet \
+  && tar xvzf ollama-linux-arm64.tgz > /dev/null \
+  && mkdir /usr/local/lib/ollama \
+  && cp -r lib/ollama/* /usr/local/lib/ollama/ \
+  && mv bin/ollama /usr/local/bin/ \
+  && rm -rf ollama* lib bin
+ENV OLLAMA_HOST=0.0.0.0 
+ENV OLLAMA_MODELS=/opt/ollama/model
+
+# Final Docker image setup.
+FROM install_ollama_${TARGETARCH}
+
+# Create Ollama directories.
+RUN set -x \
+  && mkdir /opt/ollama \
+  && mkdir /opt/ollama/model \
+  && mkdir /opt/ollama/data \
+  && mkdir /opt/ollama/log \
+  && mkdir /opt/ollama/conf \
+  && mkdir /opt/ollama/script \
+  && mkdir /opt/ollama/system \
+  && touch /opt/ollama/system/server.pid \
+  && touch /opt/ollama/system/supervisor.ini \
+  && ln -s /opt/ollama/system/supervisor.ini /etc/supervisord.d/ollama.ini \
+  && history -c
+
+# Set default work directory.
+WORKDIR /opt/ollama


### PR DESCRIPTION
Added multi-platform Dockerfiles for below core services

- APM 8.17.0
- Elasticsearch 8.17.0
- Kibana 8.17.0
- Logstash 8.17.0
- MongoDB 7.0.2
- Nginx 1.24.0
- Ollama 0.9.6

Each Dockerfile supports both `amd64` and `arm64` architectures.